### PR TITLE
Use the same UART_BAUD value of 921600 from rp2040-serial-bootloader

### DIFF
--- a/main.go
+++ b/main.go
@@ -78,7 +78,7 @@ func run() error {
 	} else {
 		options := tty.OpenOptions{
 			PortName: port,
-			BaudRate: 115200,
+			BaudRate: 921600,
 			DataBits: 8,
 			StopBits: 1,
 			MinimumReadSize: 1,


### PR DESCRIPTION
When using 115200 this tool would never show an error message and just get stuck waiting for synchronization
UART_BAUD is defined in https://github.com/usedbytes/rp2040-serial-bootloader/blob/main/main.c

I ran into this problem when trying to get your bootloader and flashing tool working together. The baud rate doesn't match and so it just gets stuck silently.