### PR TITLE
Skip bootloader parts to be able to use same elf files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+serial-flash

--- a/program/elf.go
+++ b/program/elf.go
@@ -47,6 +47,12 @@ func LoadELF(fname string, inFlash InFlashFunc) (*Image, error) {
 
 		for _, sec := range f.Sections {
 			if sec.Size > 0 && inProg(sec.Addr, sec.Size, prog) {
+				
+				// skip .app_hdr and .boot3 as they are part of the bootloader.
+				if(sec.Name == ".app_hdr" || sec.Name == ".boot3") {
+					continue
+				}
+				
 				progOffset := sec.Addr - prog.Vaddr
 				data, err := sec.Data()
 				if err != nil {


### PR DESCRIPTION
When reading the elf file, just skip the bootloader parts to keep the same target and with&without bootloader included.

When switching from Debug to Release (see my other PR), it will error as the image load address is switched.